### PR TITLE
Fix issue where warnings were appearing due to changes in Ruby 2.4.0

### DIFF
--- a/lib/pgpass.rb
+++ b/lib/pgpass.rb
@@ -62,7 +62,13 @@ module Pgpass
     end
 
     def to_hash
-      Hash[self.class.members.map{|m| [m, self[m]] }]
+      keys = Array.new
+      self.class.members.each { |m| keys.push m if !self[m].nil? }
+      keys_struct = Struct.new(*keys)
+      values = self.select { |v| !v.nil? }
+      struct_with_values = keys_struct.new(*values)
+      keys_and_values = struct_with_values.class.members.zip(values).to_h
+      return keys_and_values
     end
 
     def merge(other)


### PR DESCRIPTION
Hi there. Love your gem.

In Ruby 2.4.1 I was getting the following warnings due to the way the code iterates through the Struct.

: warning: wrong element type String at 0 (expected array)
: warning: ignoring wrong elements is deprecated, remove them explicitly
: warning: this causes ArgumentError in the next release

The changes below eliminate the errors.

Cheers.