### PR TITLE
Fix typo in 'search' hash definition inside 'match' method

### DIFF
--- a/lib/pgpass.rb
+++ b/lib/pgpass.rb
@@ -107,9 +107,9 @@ module Pgpass
 
   def match(given_options = {})
     search = Entry.create(
-      user: (ENV['PGUSER'] || '*'),
+      username: (ENV['PGUSER'] || '*'),
       password: ENV['PGPASSWORD'],
-      host: (ENV['PGHOST'] || '*'),
+      hostname: (ENV['PGHOST'] || '*'),
       port: (ENV['PGPORT'] || '*'),
       database: (ENV['PGDATABASE'] || '*')
     ).merge(given_options)


### PR DESCRIPTION
The hash used to create the `search` Entry use keys that will be simply ignored by Entry's initializer: `host` and `user`.

Instead, the keys `hostname` and `username` should be used.

The current tests pass because `hostname` and `username` are set as `nil` (because those keys were not actually passed, the keys passed were `host` and `user`). Then, the private method `compare` will treat those `nil` values the same as `*`.

`*` would have been the value set to those keys, if no PG env variable is set.

The tests are not verifying the environment variables, so the tests have been passing without problem.

In any case, this commit fix this aparently evident typo (don't merge if I'm missing something).